### PR TITLE
ci: remove deprecated set-output command

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: get commit message
         id: commitmsg
-        run: "echo ::set-output name=commitmessage::$(git log --format=%B -n 1 ${{ github.event.after }})"
+        run: echo "commitmessage=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_OUTPUT
 
       - name: Deploy
         uses: ./


### PR DESCRIPTION
Kept on getting a warning from GitHub when running this action:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

-> Just replaced the (soon to be) deprecated `set-output` command and updated the workflow to write to `GITHUB_OUTPUT` instead.